### PR TITLE
remove ringrtc workaround

### DIFF
--- a/ci-build.sh
+++ b/ci-build.sh
@@ -29,8 +29,6 @@ podman exec -it --env="PATH=/opt/node/bin:$PATH" -w /Signal-Desktop signal-deskt
 podman exec -it --env="PATH=/opt/node/bin:$PATH" -w /Signal-Desktop signal-desktop-"$VERSION" sed -i -e 's/        "deb"/        "dir"/' package.json
 # The mock tests are broken on custom arm builds
 podman exec -it --env="PATH=/opt/node/bin:$PATH" -w /Signal-Desktop signal-desktop-"$VERSION" sed -r '/mock/d' -i package.json
-# https://github.com/signalapp/ringrtc/issues/59 added 7.33 2024-11-14
-podman exec -it --env="PATH=/opt/node/bin:$PATH" -w /Signal-Desktop signal-desktop-"$VERSION" sed -e 's,"@signalapp/ringrtc": ".*","@signalapp/ringrtc": "2.48.4",' -i package.json
 # Dry run
 podman exec -it --env="PATH=/opt/node/bin:$PATH" -w /Signal-Desktop signal-desktop-"$VERSION" npm install --non-interactive
 podman exec -it --env="PATH=/opt/node/bin:$PATH"


### PR DESCRIPTION
This has been fixed: https://github.com/signalapp/ringrtc/issues/59

Built in actions and tested, and it builds/runs without the workaround on 7.34.