### PR TITLE
architecture-specific builds using new arm64 runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   pre-run:
     if: ${{ github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: workflow_dispatch pre-run info
     steps:
       - name: workflow_dispatch pre-run info
@@ -53,10 +53,11 @@ jobs:
           name: ${{ github.ref }}
           tag: ${{ github.ref }}
 
-  b-build-flatpaks:
+  # build arm64 dir on an arm64 runner, then upload it for use in the flatpak section
+  b-build-dir-arm64:
     #runs-on: self-hosted
-    runs-on: ubuntu-24.04
-    name: 'build flatpaks'
+    runs-on: ubuntu-24.04-arm
+    name: 'build dir arm64'
     steps:
       - name: Set env.BRANCH
         run: echo "BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV
@@ -70,37 +71,129 @@ jobs:
           echo "$GPG_KEY" | gpg --import
       - name: checkout code
         uses: actions/checkout@v4
-      - name: install deps
-        shell: bash
-        run: |
-          sudo apt-get update && sudo apt-get install -qq -y bash rsync flatpak elfutils coreutils slirp4netns rootlesskit binfmt-support fuse-overlayfs flatpak-builder qemu-user-static
-      - name: build dirs
+      - name: build arm64 dir
         shell: bash
         env:
           VERSION: "7.39.0"
-          build_x86_64: ${{ github.event_name != 'workflow_dispatch' || ( github.event_name == 'workflow_dispatch' && ( github.event.inputs.arch == 'both' || github.event.inputs.arch == 'x86_64' ) ) }}
           build_aarch64: ${{ github.event_name != 'workflow_dispatch' || ( github.event_name == 'workflow_dispatch' && ( github.event.inputs.arch == 'both' || github.event.inputs.arch == 'aarch64' ) ) }}
-
         run: |
-          # amd64
-          set -x
-          if [[ "$build_x86_64" == "true" ]];then
-            echo "build x86_64"
-            echo "Version is: $VERSION"
-            bash ci-build.sh amd64
-            podman stop signal-desktop-$VERSION
-            podman rm signal-desktop-$VERSION
-            mv ~/Signal-Desktop_amd64 Signal-Desktop_amd64
-          fi
           # arm64
           set -x
           if [[ "$build_aarch64" == "true" ]];then
+            sudo apt-get update && sudo apt-get install -qq -y bash rsync elfutils coreutils slirp4netns rootlesskit binfmt-support fuse-overlayfs qemu-user-static podman
             echo "build aarch64"
             echo "Version is: $VERSION"
             bash ci-build.sh arm64
             podman stop signal-desktop-$VERSION
             podman rm signal-desktop-$VERSION
             mv ~/Signal-Desktop_arm64 Signal-Desktop_arm64
+            tar czf builddir-arm64.tar.gz Signal-Desktop_arm64
+          fi
+      - name: Upload arm64 dir
+        if: ${{ github.event_name != 'workflow_dispatch' || ( github.event_name == 'workflow_dispatch' && ( github.event.inputs.arch == 'both' || github.event.inputs.arch == 'aarch64' ) ) }}
+        uses: actions/upload-artifact@v4
+        with:
+          path: builddir-arm64.tar.gz
+          name: builddir-arm64
+          retention-days: 1
+
+  b-build-dir-amd64:
+    #runs-on: self-hosted
+    runs-on: ubuntu-24.04
+    name: 'build dir x86_64'
+    steps:
+      - name: Set env.BRANCH
+        run: echo "BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV
+      - name: install secrets
+        shell: bash
+        env:
+          GPG_KEY: ${{secrets.GPG_KEY}}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -qq -y gpg openssh-client
+          echo "$GPG_KEY" | gpg --import
+      - name: checkout code
+        uses: actions/checkout@v4
+      - name: build x86_64 dir
+        shell: bash
+        env:
+          VERSION: "7.39.0"
+          build_x86_64: ${{ github.event_name != 'workflow_dispatch' || ( github.event_name == 'workflow_dispatch' && ( github.event.inputs.arch == 'both' || github.event.inputs.arch == 'x86_64' ) ) }}
+        run: |
+          # arm64
+          set -x
+          if [[ "$build_x86_64" == "true" ]];then
+            sudo apt-get update && sudo apt-get install -qq -y bash rsync elfutils coreutils slirp4netns rootlesskit binfmt-support fuse-overlayfs qemu-user-static podman
+            echo "build x86_64"
+            echo "Version is: $VERSION"
+            bash ci-build.sh amd64
+            podman stop signal-desktop-$VERSION
+            podman rm signal-desktop-$VERSION
+            mv ~/Signal-Desktop_amd64 Signal-Desktop_amd64
+            tar czf builddir-amd64.tar.gz Signal-Desktop_amd64
+          fi
+      - name: Upload x86_64 dir
+        if: ${{ github.event_name != 'workflow_dispatch' || ( github.event_name == 'workflow_dispatch' && ( github.event.inputs.arch == 'both' || github.event.inputs.arch == 'x86_64' ) ) }}
+        uses: actions/upload-artifact@v4
+        with:
+          path: builddir-amd64.tar.gz
+          name: builddir-amd64
+          retention-days: 1
+
+  b-build-flatpaks:
+    #runs-on: self-hosted
+    runs-on: ubuntu-24.04
+    name: 'build flatpaks'
+    needs:
+      - b-build-dir-arm64
+      - b-build-dir-amd64
+    steps:
+      - name: Set env.BRANCH
+        run: echo "BRANCH=$(echo $GITHUB_REF | cut -d'/' -f 3)" >> $GITHUB_ENV
+      - name: install secrets
+        shell: bash
+        env:
+          GPG_KEY: ${{secrets.GPG_KEY}}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -qq -y gpg openssh-client
+          echo "$GPG_KEY" | gpg --import
+      - name: checkout code
+        uses: actions/checkout@v4
+      - name: Download arm64 artifacts
+        if: ${{ github.event_name != 'workflow_dispatch' || ( github.event_name == 'workflow_dispatch' && ( github.event.inputs.arch == 'both' || github.event.inputs.arch == 'aarch64' ) ) }}
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/
+          name: builddir-arm64
+      - name: Download x86_64 artifacts
+        if: ${{ github.event_name != 'workflow_dispatch' || ( github.event_name == 'workflow_dispatch' && ( github.event.inputs.arch == 'both' || github.event.inputs.arch == 'x86_64' ) ) }}
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/
+          name: builddir-amd64
+      - name: install deps
+        shell: bash
+        run: |
+          sudo apt-get update && sudo apt-get install -qq -y bash rsync flatpak elfutils coreutils slirp4netns rootlesskit binfmt-support fuse-overlayfs flatpak-builder qemu-user-static unzip
+      - name: build dirs
+        shell: bash
+        env:
+          VERSION: "7.39.0"
+          build_x86_64: ${{ github.event_name != 'workflow_dispatch' || ( github.event_name == 'workflow_dispatch' && ( github.event.inputs.arch == 'both' || github.event.inputs.arch == 'x86_64' ) ) }}
+          build_aarch64: ${{ github.event_name != 'workflow_dispatch' || ( github.event_name == 'workflow_dispatch' && ( github.event.inputs.arch == 'both' || github.event.inputs.arch == 'aarch64' ) ) }}
+        run: |
+          # amd64
+          set -x
+          if [[ "$build_x86_64" == "true" ]];then
+            tar xzf /tmp/builddir-amd64.tar.gz
+            ls -alh Signal-Desktop_amd64
+          fi
+          # arm64
+          set -x
+          if [[ "$build_aarch64" == "true" ]];then
+            tar xzf /tmp/builddir-arm64.tar.gz
+            ls -alh Signal-Desktop_arm64
           fi
       - name: install flatpak deps
         shell: bash


### PR DESCRIPTION
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

- builds will run on the runner for their own architecture
- flatpak build depends on the dir builds
- the dir builds will always run, but some steps of the build (actually
  building or uploading the artifact) will not run if the architecture
  is not specified in the workflow_dispatch
- the flatpak build will also not download the artifact for that
  architecture if it's not selected

Arguably since amd64 and arm64 build in about the same amount of time on native runners, selecting only one architecture has no benefit.