### PR TITLE
update to 25.08 runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,8 +203,8 @@ jobs:
           sudo chown "$USER" /opt/pakrepo
           sudo flatpak update --noninteractive -y
           sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          sudo flatpak install --noninteractive --arch=aarch64 flathub org.electronjs.Electron2.BaseApp//24.08 org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08 -y
-          sudo flatpak install --noninteractive --arch=x86_64 flathub org.electronjs.Electron2.BaseApp//24.08 org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08 -y
+          sudo flatpak install -y --noninteractive --arch=aarch64 flathub org.electronjs.Electron2.BaseApp//25.08 org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
+          sudo flatpak install -y --noninteractive --arch=x86_64 flathub org.electronjs.Electron2.BaseApp//25.08 org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
       - name: build flatpaks
         shell: bash
         env:

--- a/flatpak.yml
+++ b/flatpak.yml
@@ -1,8 +1,8 @@
 id: org.signal.Signal
 base: org.electronjs.Electron2.BaseApp
-base-version: '24.08'
+base-version: '25.08'
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: signal-desktop
 separate-locales: false


### PR DESCRIPTION
https://github.com/flathub/org.electronjs.Electron2.BaseApp
25.08 runtimes are out.