### PR TITLE
build in custom image

### DIFF
--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -1,7 +1,7 @@
 name: run autobuild.sh
 on:
   schedule:
-    - cron: '0 0 * * 6'
+    - cron: '0 1 * * 6'
   workflow_dispatch:
 jobs:
   autobuild-sh:

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -15,10 +15,11 @@ fi
 NODE_VERSION=v22.18.0
 
 shopt -s localvar_inherit
-podman create --name=signal-desktop-"$VERSION" --arch "$ARCHSPECIFICVARIABLECOMMON" -it debian:bookworm bash
+podman create --name=signal-desktop-"$VERSION" --arch "$ARCHSPECIFICVARIABLECOMMON" -it ghcr.io/signalflatpak/image:latest bash
+#podman create --name=signal-desktop-"$VERSION" --arch "$ARCHSPECIFICVARIABLECOMMON" -it debian:bookworm bash
 podman start signal-desktop-"$VERSION"
 podman exec -it --env="PATH=/opt/node/bin:$PATH" signal-desktop-"$VERSION" apt -qq update
-podman exec -it --env="PATH=/opt/node/bin:$PATH" signal-desktop-"$VERSION" apt -qq install -y python3 gcc g++ make build-essential git git-lfs libffi-dev libssl-dev libglib2.0-0 libnss3 libatk1.0-0 libatk-bridge2.0-0 libx11-xcb1 libgdk-pixbuf-2.0-0 libgtk-3-0 libdrm2 libgbm1 ruby ruby-dev curl wget clang llvm lld clang-tools generate-ninja ninja-build pkg-config tcl wget libpixman-1-dev libcairo2-dev libpango1.0-dev
+#podman exec -it --env="PATH=/opt/node/bin:$PATH" signal-desktop-"$VERSION" apt -qq install -y python3 gcc g++ make build-essential git git-lfs libffi-dev libssl-dev libglib2.0-0 libnss3 libatk1.0-0 libatk-bridge2.0-0 libx11-xcb1 libgdk-pixbuf-2.0-0 libgtk-3-0 libdrm2 libgbm1 ruby ruby-dev curl wget clang llvm lld clang-tools generate-ninja ninja-build pkg-config tcl wget libpixman-1-dev libcairo2-dev libpango1.0-dev
 podman exec -it --env="PATH=/opt/node/bin:$PATH" signal-desktop-"$VERSION" git clone https://github.com/signalapp/Signal-Desktop -b 7.72.x
 podman exec -it --env="PATH=/opt/node/bin:$PATH" -w /opt/ signal-desktop-"$VERSION" wget -q https://nodejs.org/dist/"$NODE_VERSION"/node-"$NODE_VERSION"-linux-"$ARCHSPECIFICVARIABLESHORT".tar.gz
 podman exec -it --env="PATH=/opt/node/bin:$PATH" -w /opt/ signal-desktop-"$VERSION" tar xf node-"$NODE_VERSION"-linux-"$ARCHSPECIFICVARIABLESHORT".tar.gz


### PR DESCRIPTION
Switching to building in this image: https://github.com/signalflatpak/image instead of debian:bookworm. It's a debian 13 image that will include the dependencies we're installing anyway. 

This should save a little bit of build time. Docker was also down yesterday when 7.72 was building so it couldn't pull the bookworm image from docker hub, and this should solve that potential problem too.